### PR TITLE
fix: asanaのアップデートに対応

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,14 +1,16 @@
 chrome.runtime.onMessage.addListener(
 	function(request, sendler, sentResponse) {
+		const task_title_class = "ProjectPageHeader-projectName--colorNone ProjectPageHeader-projectName";
+
 		//タイトルの名前を取得
 		let content_title = document.getElementsByTagName('title')[0].textContent;		
 
 		//ヘッダー名(プロジェクト名など)を取得
-		let header_element = document.getElementsByClassName('PageHeaderStructure-title')[0]
+		let header_element = document.getElementsByClassName(task_title_class)[0]
 		let header_name = null;
 
 		if (header_element) {
-			header_name = document.getElementsByClassName('PageHeaderStructure-title')[0].textContent;
+			header_name = document.getElementsByClassName(task_title_class)[0].title;
 		}
 
 		let task_name = null;

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name":"Link converter for Asana",
-  "version":"1.1.0",
+  "version":"1.1.1",
   "description": "copy task name on asana as markdown",
   "content_scripts": [{
     "matches": ["https://app.asana.com/*"],


### PR DESCRIPTION
Asanaのアプデでタスク名が抽出できなくなった問題を解決しました。